### PR TITLE
forward oc error

### DIFF
--- a/library/OrderCloud.Catalyst/Auth/UserAuth/OrderCloudUserAuth.cs
+++ b/library/OrderCloud.Catalyst/Auth/UserAuth/OrderCloudUserAuth.cs
@@ -69,6 +69,10 @@ namespace OrderCloud.Catalyst
 			{
 				throw ex;
 			}
+			catch (OrderCloudException ex)
+			{
+				throw ex;
+			}
 			catch (Exception ex) {
 				throw new UnAuthorizedException();
 			}

--- a/library/OrderCloud.Catalyst/Auth/UserAuth/UserContextProvider.cs
+++ b/library/OrderCloud.Catalyst/Auth/UserAuth/UserContextProvider.cs
@@ -51,11 +51,15 @@ namespace OrderCloud.Catalyst
                 {
                     return _oc.Me.GetAsync(token);
                 }
+                catch (OrderCloudException ex) 
+                {
+                    throw ex;
+			    }
                 catch (FlurlHttpException ex) when ((int?)ex.Call.Response?.StatusCode < 500)
                 {
                     return null;
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     allowFetchUserRetry = true;
                     return null;

--- a/library/OrderCloud.Catalyst/Errors/GlobalExceptionHandler.cs
+++ b/library/OrderCloud.Catalyst/Errors/GlobalExceptionHandler.cs
@@ -40,7 +40,7 @@ namespace OrderCloud.Catalyst
                     return context.Response.WriteAsync(JsonConvert.SerializeObject(intException.ApiError));
                 case OrderCloudException ocException:
                     context.Response.StatusCode = (int) ocException.HttpStatus;
-                    return context.Response.WriteAsync(JsonConvert.SerializeObject(ocException.Errors));
+                    return context.Response.WriteAsync(JsonConvert.SerializeObject(ocException.Errors[0]));
             }
 
             // this is only to be hit IF it's not handled properly in the stack. It's considered a bug if ever hits this. that's why it's a 500

--- a/tests/OrderCloud.Catalyst.TestApi/Controllers/DemoController.cs
+++ b/tests/OrderCloud.Catalyst.TestApi/Controllers/DemoController.cs
@@ -4,7 +4,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using OrderCloud.Catalyst;
 using OrderCloud.SDK;
 using RequiredAttribute = System.ComponentModel.DataAnnotations.RequiredAttribute;
 

--- a/tests/OrderCloud.Catalyst.Tests/ApiIntegrationTests/UserAuthTests.cs
+++ b/tests/OrderCloud.Catalyst.Tests/ApiIntegrationTests/UserAuthTests.cs
@@ -84,6 +84,26 @@ namespace OrderCloud.Catalyst.Tests
 			result.Should().Be("\"hello joe!\"");
 		}
 
+		[TestCase("Auth.InvalidUsernameOrPassword", 401, "Invalid username or password")]
+		[TestCase("InvalidToken", 401, "Access token is invalid or expired.")]
+		public async Task ordercloud_error_should_be_forwarded(string errorCode, int statusCode, string message)
+		{
+			var token = FakeOrderCloudToken.Create("some_new_client_id23");
+			var request = TestFramework.Client
+				.WithOAuthBearerToken(token)
+				.Request("demo/shop");
+			var error = OrderCloudExceptionFactory.Create((HttpStatusCode)statusCode, "", new ApiError[] { new ApiError() { 
+				Message = message,
+				ErrorCode = errorCode,
+			}});
+
+			TestStartup.oc.Me.GetAsync(token).Returns<MeUser>(x => { throw error; });
+
+			var result = await request.GetAsync();
+
+			result.ShouldBeApiError(errorCode, statusCode, message);
+		}
+
 		[Test]
 		public async Task should_succeed_with_order_admin()
 		{
@@ -98,16 +118,16 @@ namespace OrderCloud.Catalyst.Tests
 				ID = "",
 				Active = true,
 				AvailableRoles = new[] {
-				"MeAdmin",
-				"MeXpAdmin",
-				"ProductAdmin",
-				"PriceScheduleAdmin",
-				"SupplierReader",
-				"OrderAdmin",
-				"SupplierAdmin",
-				"SupplierUserAdmin",
-				"MPMeSupplierUserAdmin",
-				"MPSupplierUserGroupAdmin"
+					"MeAdmin",
+					"MeXpAdmin",
+					"ProductAdmin",
+					"PriceScheduleAdmin",
+					"SupplierReader",
+					"OrderAdmin",
+					"SupplierAdmin",
+					"SupplierUserAdmin",
+					"MPMeSupplierUserAdmin",
+					"MPSupplierUserGroupAdmin"
 				}
 			});
 

--- a/tests/OrderCloud.Catalyst.Tests/OrderCloudExceptionFactory.cs
+++ b/tests/OrderCloud.Catalyst.Tests/OrderCloudExceptionFactory.cs
@@ -1,0 +1,31 @@
+﻿using OrderCloud.SDK;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace OrderCloud.Catalyst.Tests
+{
+	public class OrderCloudExceptionFactory
+	{
+		private static Type _ocExceptionType = typeof(OrderCloudException);
+		private static Type _exceptionType = typeof(Exception);
+		private static FieldInfo _httpStatusField = _ocExceptionType.GetField("<HttpStatus>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+		private static FieldInfo _errorsField = _ocExceptionType.GetField("<Errors>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+		private static FieldInfo _messageField = _exceptionType.GetField("_message", BindingFlags.Instance | BindingFlags.NonPublic);
+		private static FieldInfo _dataField = _exceptionType.GetField("_data", BindingFlags.Instance | BindingFlags.NonPublic);
+
+		public static OrderCloudException Create(HttpStatusCode status, string message = null, ApiError[] errors = null, IDictionary data = null)
+		{
+			var ex = (OrderCloudException)FormatterServices.GetUninitializedObject(typeof(OrderCloudException));
+			_httpStatusField.SetValue(ex, status);
+			_messageField.SetValue(ex, message);
+			_errorsField.SetValue(ex, errors);
+			_dataField.SetValue(ex, data);
+			return ex;
+		}
+	}
+}


### PR DESCRIPTION
Any error thrown by Ordercloud during the GET /me authorize step is forwarded by catalyst directly to the client