### PR TITLE
HDS-326: Add Require class to Catalyst

### DIFF
--- a/library/OrderCloud.Catalyst/Errors/Require.cs
+++ b/library/OrderCloud.Catalyst/Errors/Require.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace OrderCloud.Catalyst
+{
+    public static class Require
+    {
+        /// <summary>
+        /// Throws an error if condition is false. HTTP status is defined in the ErrorCode object. 
+        /// Example usage: Require.That(check == true, CatalystException.NotFound, SomeObject); 
+        /// See ErrorCodes.txt for error definitions 
+        /// </summary>
+        public static void That<TModel>(bool condition, CatalystBaseException error, TModel model)
+        {
+            if (!condition)
+            {
+                throw new CatalystBaseException(error.ApiError.ErrorCode, error.ApiError.Message, model);
+            }
+        }
+
+        /// <summary>
+        /// Throws an error if condition is false. Error data model is built lazily. HTTP status is defined in the ErrorCode object. 
+        /// Example usage: Require.That(check == true, CatalystException.NotFound, () => new { key = "value" }); 
+        /// </summary>
+        public static void That<TModel>(bool condition, CatalystBaseException error, Func<TModel> buildModel)
+        {
+            if (!condition)
+            {
+                throw new CatalystBaseException(error.ApiError.ErrorCode, error.ApiError.Message, buildModel());
+            }
+        }
+        /// <summary>
+        /// Overload for when you don't need to pass back an object
+        /// </summary>
+        public static void That(bool condition, CatalystBaseException error, object data = null)
+        {
+            if (!condition)
+            {
+                throw new CatalystBaseException(error.ApiError.ErrorCode, error.ApiError.Message, data);
+            }
+        }
+    }
+}

--- a/tests/OrderCloud.Catalyst.Tests/ApiIntegrationTests/GeneralErrorTests.cs
+++ b/tests/OrderCloud.Catalyst.Tests/ApiIntegrationTests/GeneralErrorTests.cs
@@ -1,8 +1,7 @@
-﻿using Flurl.Http;
+﻿using AutoFixture.NUnit3;
+using Flurl.Http;
 using NUnit.Framework;
 using OrderCloud.SDK;
-using System;
-using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -25,14 +24,44 @@ namespace OrderCloud.Catalyst.Tests
 			result.ShouldBeApiError("InternalServerError", 500, "Unknown error has occured.");
 		}
 
-		[TestCase("something")]
-		public async Task catalsyst_exception_should_have_message(string message)
+		[Test]
+		[AutoData]
+		public void catalsyst_exception_should_have_message(string code, string message)
 		{
-			var ex1 = new CatalystBaseException(new ApiError() { Message = message });
-			var ex2 = new CatalystBaseException("code", message);
+			var ex1 = new CatalystBaseException(new ApiError() { ErrorCode = code, Message = message });
+			var ex2 = new CatalystBaseException(code, message);
 
 			Assert.AreEqual(message, ex1.Message);
 			Assert.AreEqual(message, ex2.Message);
+			Assert.AreEqual(code, ex1.ApiError.ErrorCode);
+			Assert.AreEqual(code, ex2.ApiError.ErrorCode);
+		}
+
+		[Test]
+		public void require_that_does_not_throw_catalyst_exception()
+        {
+			Assert.DoesNotThrow(() => Require.That(true, new CatalystBaseException("code", "message")));
+		}
+
+		[Test]
+		[AutoData]
+		public void require_that_throws_catalyst_exception(string code, string message)
+        {
+			var data = new { key = "value" };
+			var ex1 = Assert.Throws<CatalystBaseException>(() => Require.That(false, new CatalystBaseException(code, message)));
+			var ex2 = Assert.Throws<CatalystBaseException>(() => Require.That(false, new CatalystBaseException(new ApiError() { ErrorCode = code, Message = message })));
+			var ex3 = Assert.Throws<CatalystBaseException>(() => Require.That(false, new CatalystBaseException(new ApiError() { ErrorCode = code, Message = message }), data));
+			var ex4 = Assert.Throws<CatalystBaseException>(() => Require.That(false, new CatalystBaseException(code, message), () => data));
+			Assert.AreEqual(message, ex1.Message);
+			Assert.AreEqual(message, ex2.Message);
+			Assert.AreEqual(message, ex3.Message);
+			Assert.AreEqual(message, ex4.Message);
+			Assert.AreEqual(code, ex1.ApiError.ErrorCode);
+			Assert.AreEqual(code, ex2.ApiError.ErrorCode);
+			Assert.AreEqual(code, ex3.ApiError.ErrorCode);
+			Assert.AreEqual(code, ex4.ApiError.ErrorCode);
+			Assert.AreEqual(data, ex3.ApiError.Data);
+			Assert.AreEqual(data, ex4.ApiError.Data);
 		}
 	}
 }


### PR DESCRIPTION
- Add Require class to Catalyst, contains 3 methods, different variations of "That"
- Added tests to the GeneralErrorTests to cover these methods