### PR TITLE
Feature/fix past expiry unit test

### DIFF
--- a/library/OrderCloud.Catalyst/Auth/UserAuth/FakeOrderCloudToken.cs
+++ b/library/OrderCloud.Catalyst/Auth/UserAuth/FakeOrderCloudToken.cs
@@ -52,8 +52,8 @@ namespace OrderCloud.Catalyst.Auth.UserAuth
 				issuer: authUrl ?? "mockdomain.com",
 				audience: apiUrl ?? "mockdomain.com",
 				claims: claims,
-				expires: expiresUTC ?? DateTime.UtcNow.AddMinutes(30),
-				notBefore: notValidBeforeUTC ?? DateTime.UtcNow
+				expires: expiresUTC ?? DateTime.Now.AddMinutes(30),
+				notBefore: notValidBeforeUTC ?? DateTime.Now
 			);
 
 			var token = new JwtSecurityToken(header, payload);

--- a/library/OrderCloud.Catalyst/Auth/UserAuth/FakeOrderCloudToken.cs
+++ b/library/OrderCloud.Catalyst/Auth/UserAuth/FakeOrderCloudToken.cs
@@ -52,8 +52,8 @@ namespace OrderCloud.Catalyst.Auth.UserAuth
 				issuer: authUrl ?? "mockdomain.com",
 				audience: apiUrl ?? "mockdomain.com",
 				claims: claims,
-				expires: expiresUTC ?? DateTime.Now.AddMinutes(30),
-				notBefore: notValidBeforeUTC ?? DateTime.Now
+				expires: expiresUTC ?? DateTime.UtcNow.AddMinutes(30),
+				notBefore: notValidBeforeUTC ?? DateTime.UtcNow
 			);
 
 			var token = new JwtSecurityToken(header, payload);

--- a/tests/OrderCloud.Catalyst.Tests/ApiIntegrationTests/UserAuthTests.cs
+++ b/tests/OrderCloud.Catalyst.Tests/ApiIntegrationTests/UserAuthTests.cs
@@ -234,7 +234,8 @@ namespace OrderCloud.Catalyst.Tests
 			var token = FakeOrderCloudToken.Create(
 				clientID: fixture.Create<string>(),
 				roles: new List<string> { "Shopper" },
-				expiresUTC: DateTime.UtcNow - TimeSpan.FromHours(1)
+				expiresUTC: DateTime.UtcNow,
+				notValidBeforeUTC: DateTime.UtcNow - TimeSpan.FromHours(1)
 			);
 
 			var resp = await TestFramework.Client

--- a/tests/OrderCloud.Catalyst.Tests/ApiIntegrationTests/UserAuthTests.cs
+++ b/tests/OrderCloud.Catalyst.Tests/ApiIntegrationTests/UserAuthTests.cs
@@ -234,8 +234,7 @@ namespace OrderCloud.Catalyst.Tests
 			var token = FakeOrderCloudToken.Create(
 				clientID: fixture.Create<string>(),
 				roles: new List<string> { "Shopper" },
-				expiresUTC: DateTime.UtcNow,
-				notValidBeforeUTC: DateTime.UtcNow - TimeSpan.FromHours(1)
+				expiresUTC: DateTime.UtcNow - TimeSpan.FromHours(1)
 			);
 
 			var resp = await TestFramework.Client


### PR DESCRIPTION
1) Fixed the `should_deny_access_if_past_expiry` unit test.
2) Updated the Create method of the `FakeOrderCloudToken` class to avoid mixing `DateTime.Now` and `DateTime.UtcNow`.