### PR TITLE
Add more null reference checks

### DIFF
--- a/library/OrderCloud.Catalyst/Errors/GlobalExceptionHandler.cs
+++ b/library/OrderCloud.Catalyst/Errors/GlobalExceptionHandler.cs
@@ -41,12 +41,12 @@ namespace OrderCloud.Catalyst
                     body = intException.Errors;
                     break;
                 case OrderCloudException ocException:
-                    var isClientSerializationError = ocException.Errors == null;
+                    var isClientSerializationError = ocException?.Errors == null;
 					if (isClientSerializationError) // 500 error with interal error message, this is a bug in the client API
 					{
                         body = new List<ApiError>() {
                             new ApiError() {
-                                Data = ocException.InnerException.InnerException.Message, // "Response could not be deserialized...."
+                                Data = ocException?.InnerException?.InnerException?.Message, // "Response could not be deserialized...."
                                 ErrorCode = "OrderCloudSDKDeserializationError",
                                 Message = ocException.Message // Specific path and value of error
                             }


### PR DESCRIPTION
We noticed a null reference exception in Catalyst's exception handler that caused a failed request to incorrectly look like a CORS issue and didn't let us get better details on the true failure

![image](https://user-images.githubusercontent.com/16483662/146446195-39109c82-700f-4444-8fc0-702f4bb9412c.png)
