### PR TITLE
Update RequestAuthenticationService.cs

### DIFF
--- a/library/OrderCloud.Catalyst/Auth/UserAuth/RequestAuthenticationService.cs
+++ b/library/OrderCloud.Catalyst/Auth/UserAuth/RequestAuthenticationService.cs
@@ -219,7 +219,7 @@ namespace OrderCloud.Catalyst
 				}
 				catch (OrderCloudException ex)
 				{
-					return false;
+					throw ex;
 				}
 				catch (Exception ex)
 				{


### PR DESCRIPTION
Hi, @oliverheywood451, could you please check this fix?
It's related to this issue: https://github.com/ordercloud-api/ordercloud-dotnet-catalyst/issues/48
Where a few test cases were failed because the KeyID is null.

Looks like the test cases started to fail because of the next commit change in the `RequestAuthenticationService` class: 259733541f9e8f06c05f57a2d155e499564ec06c [2597335]
Was it expected?

Now I've back the `throw ex` from the `return false` statement to make the analogy with the `private async Task<bool> VerifyTokenWithKeyID(DecodedToken jwt)` method which forwards only the specific `OrderCloudException` exception, hence the mentioned use cases passes again.

