### PR TITLE
v1.5.2 Reverted the `throw` from the GlobalExceptionHandler and incre…

### DIFF
--- a/library/OrderCloud.Catalyst/Errors/GlobalExceptionHandler.cs
+++ b/library/OrderCloud.Catalyst/Errors/GlobalExceptionHandler.cs
@@ -23,7 +23,6 @@ namespace OrderCloud.Catalyst
                 catch (Exception ex)
                 {
                     await HandleExceptionAsync(context, ex);
-                    throw;
                 }
             });
             return builder;

--- a/library/OrderCloud.Catalyst/OrderCloud.Catalyst.csproj
+++ b/library/OrderCloud.Catalyst/OrderCloud.Catalyst.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>1.5.1</Version>
+    <Version>1.5.2</Version>
     <PackageId>ordercloud-dotnet-catalyst</PackageId>
     <Title>OrderCloud SDK Extensions for Azure App Services</Title>
     <Authors>Oliver Heywood</Authors>


### PR DESCRIPTION
v1.5.2 Reverted the `throw` from the GlobalExceptionHandler and increased the version because of the updated behavior and a couple of minor fixes in previous PRs.

The PR fixed the remaining fails in unit tests:
![image](https://user-images.githubusercontent.com/1814356/147092236-3632c5fa-1986-4aa3-b361-fd966aa3dc75.png)

The linked issue with a detailed description of why this change is needed: https://github.com/ordercloud-api/ordercloud-dotnet-catalyst/issues/47