### PR TITLE
Update to how single merchant CCTransactionResult is mapped

### DIFF
--- a/OrderCloud.Catalyst/OrderCloud.Catalyst.csproj
+++ b/OrderCloud.Catalyst/OrderCloud.Catalyst.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <PackageId>ordercloud-dotnet-catalyst</PackageId>
     <Title>OrderCloud SDK Extensions for Azure App Services</Title>
 	<Authors>OrderCloud Team</Authors>


### PR DESCRIPTION
Undo a change to MapAuthorizedPaymentToCCTransactionResult & MapCapturedPaymentToCCTransactionResult that would have resulted in a breaking change.

Increase version to 2.6.0