### PR TITLE
Add InitializePaymentRequestAsync method for stripe

### DIFF
--- a/OrderCloud.Integrations.Payment.Stripe/Mappers/StripePaymentIntentMapper.cs
+++ b/OrderCloud.Integrations.Payment.Stripe/Mappers/StripePaymentIntentMapper.cs
@@ -48,6 +48,21 @@ namespace OrderCloud.Integrations.Payment.Stripe.Mappers
             };
         }
 
+        public PaymentIntentCreateOptions MapPaymentIntentOnlyOptions(AuthorizeCCTransaction transaction)
+        {
+            var coefficient = IsZeroDecimalCurrency(transaction.Currency) ? 1 : 100;
+            return new PaymentIntentCreateOptions()
+            {
+                Amount = Convert.ToInt64((transaction.Amount * coefficient)),
+                Currency = transaction.Currency,
+                Customer = transaction.ProcessorCustomerID,
+                AutomaticPaymentMethods = new PaymentIntentAutomaticPaymentMethodsOptions
+                {
+                    Enabled = true, // Creates PaymentIntent only- used to send Client Secret back to iframe 
+                }
+            };
+        }
+
         public CCTransactionResult MapPaymentIntentCreateAndConfirmResponse(PaymentIntent createdPaymentIntent) =>
             new CCTransactionResult()
             {
@@ -57,6 +72,12 @@ namespace OrderCloud.Integrations.Payment.Stripe.Mappers
                     createdPaymentIntent
                         .Id, // transaction.TransactionID represents PaymentMethodID, this now represents PaymentIntentID
                 Amount = createdPaymentIntent.Amount
+            };
+
+        public CCTransactionResult MapPaymentIntentCreateResponse(PaymentIntent createdPaymentIntent) =>
+            new CCTransactionResult()
+            {
+                TransactionID = createdPaymentIntent.ClientSecret // transaction.TransactionID represents Client Secret for the Stripe payment iframe in this case
             };
 
         public PaymentIntentCaptureOptions MapPaymentIntentCaptureOptions(FollowUpCCTransaction transaction)

--- a/OrderCloud.Integrations.Payment.Stripe/OrderCloud.Integrations.Payment.Stripe.csproj
+++ b/OrderCloud.Integrations.Payment.Stripe/OrderCloud.Integrations.Payment.Stripe.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <PackageId>OrderCloud.Integrations.Payment.Stripe</PackageId>
     <Title>OrderCloud Tax Integration with Stripe</Title>
     <Authors>OrderCloud Team</Authors>

--- a/OrderCloud.Integrations.Payment.Stripe/StripeClient.cs
+++ b/OrderCloud.Integrations.Payment.Stripe/StripeClient.cs
@@ -78,7 +78,7 @@ namespace OrderCloud.Integrations.Payment.Stripe
         /// <summary>
         /// https://stripe.com/docs/api/payment_intents/create
         /// </summary>
-        public static async Task<PaymentIntent> CreateAndConfirmPaymentIntentAsync(PaymentIntentCreateOptions options, StripeConfig config)
+        public static async Task<PaymentIntent> CreatePaymentIntentAsync(PaymentIntentCreateOptions options, StripeConfig config)
         {
             StripeConfiguration.ApiKey = config.SecretKey;
             var service = new PaymentIntentService();

--- a/OrderCloud.Integrations.Payment.Stripe/StripeService.cs
+++ b/OrderCloud.Integrations.Payment.Stripe/StripeService.cs
@@ -19,9 +19,13 @@ namespace OrderCloud.Integrations.Payment.Stripe
             return token;
         }
 
-        public Task<CCTransactionResult> InitializePaymentRequestAsync(AuthorizeCCTransaction transaction, OCIntegrationConfig overrideConfig = null, bool isCapture = false)
+        public async Task<CCTransactionResult> InitializePaymentRequestAsync(AuthorizeCCTransaction transaction, OCIntegrationConfig overrideConfig = null, bool isCapture = false)
         {
-            throw new NotImplementedException();
+            var config = ValidateConfig<StripeConfig>(overrideConfig ?? _defaultConfig);
+            var paymentIntentMapper = new StripePaymentIntentMapper();
+            var paymentIntentCreateOptions = paymentIntentMapper.MapPaymentIntentOnlyOptions(transaction);
+            var createdPaymentIntent = await StripeClient.CreatePaymentIntentAsync(paymentIntentCreateOptions, config);
+            return paymentIntentMapper.MapPaymentIntentCreateResponse(createdPaymentIntent);
         }
 
         public Task<CCTransactionResult> CapturePaymentAsync(FollowUpCCTransaction transaction, OCIntegrationConfig overrideConfig = null)
@@ -36,7 +40,7 @@ namespace OrderCloud.Integrations.Payment.Stripe
                 var config = ValidateConfig<StripeConfig>(configOverride ?? _defaultConfig);
                 var paymentIntentMapper = new StripePaymentIntentMapper();
                 var paymentIntentCreateOptions = paymentIntentMapper.MapPaymentIntentCreateAndConfirmOptions(transaction);
-                var createdPaymentIntent = await StripeClient.CreateAndConfirmPaymentIntentAsync(paymentIntentCreateOptions, config);
+                var createdPaymentIntent = await StripeClient.CreatePaymentIntentAsync(paymentIntentCreateOptions, config); // confirms payment intent as well
                 return paymentIntentMapper.MapPaymentIntentCreateAndConfirmResponse(createdPaymentIntent);
             }
         }


### PR DESCRIPTION
This PR introduces a new method, `InitializePaymentRequestAsync()`, to the Catalyst Stripe integration. It's designed to support advanced Stripe payment flows (e.g, Stripe Elements or Payment Element) by returning a `client_secret` used to initialize the Stripe iframe on the frontend.

**New Features**
`InitializePaymentRequestAsync()`
- Accepts an AuthorizeCCTransaction request.
- Creates a PaymentIntent using Stripe’s API with AutomaticPaymentMethods.Enabled = true.
- Returns a CCTransactionResult with the Stripe client_secret populated in the TransactionID property.

**Usage**
- The TransactionID (which holds the client_secret) can be passed directly to the frontend and used to initialize Stripe Elements.
- Designed to work with frontend setups using stripe.confirmCardPayment().